### PR TITLE
Case-insensitive vendor name matching

### DIFF
--- a/tools/cpu_monitor.py
+++ b/tools/cpu_monitor.py
@@ -24,9 +24,9 @@ class CPUMonitor:
             vendor_name = RE_CPU_VENDOR.search(f.read())
             vendor_name = vendor_name.group(1) if vendor_name else None
 
-        if "AMD" in vendor_name:
+        if "amd" in vendor_name.casefold():
             return "AMD"
-        elif "INTEL" in vendor_name:
+        elif "intel" in vendor_name.casefold():
             return "INTEL"
 
         return vendor_name


### PR DESCRIPTION
Fixes case-sensitive vendor name matching.
In case the vendor id is something like `GenuineIntel` as I found on a `Intel(R) Atom(TM) CPU C3758`. 